### PR TITLE
fix: Repair non-functional hamburger menu

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -14,7 +14,6 @@ header {
     box-shadow: var(--box-shadow); /* Kept as per instructions */
     margin-bottom: 20px;
     position: relative;
-    overflow: hidden; /* Kept, useful if any child elements were to overflow */
     background-size: 250% 250%;
     animation: gradient-flow 18s ease infinite;
 }


### PR DESCRIPTION
This commit fixes a critical bug that was preventing the mobile hamburger menu from displaying correctly. The `overflow: hidden;` property on the `header` element was clipping the dropdown menu, making it invisible.

This property has been removed, and the hamburger menu is now fully functional.